### PR TITLE
Fix bug with Move

### DIFF
--- a/mods/essb/moves.js
+++ b/mods/essb/moves.js
@@ -921,7 +921,7 @@ exports.BattleMovedex = {
         },
         basePower: 0,
         pp: 15,
-        accuracy: 100,
+        accuracy: true,
         target: "self",
         type: "Bug",
     },


### PR DESCRIPTION
Team player can miss if raised its evasiveness. SHould activate regardless